### PR TITLE
Feat/Reset password by email

### DIFF
--- a/frontend/components/navbar/NavBar.jsx
+++ b/frontend/components/navbar/NavBar.jsx
@@ -4,7 +4,7 @@ import { AuthContext } from "../../context/authContext/AuthContext";
 import axios from "../axios";
 import dynamic from "next/dynamic";
 import router from "next/router";
-import { toast } from 'react-toastify';
+import { toast } from "react-toastify";
 
 // Use dynamic import NextJS
 const NavNonAuth = dynamic(() => import("./NavNonAuth"), { ssr: false });
@@ -16,12 +16,27 @@ const NavBar = () => {
     const [searchTerm, setSearchTerm] = useState("");
 
     useEffect(() => {
-        axios
-            .get("/categories")
-            .then((res) => setCategories(res.data.data.categories))
-            .catch((error) => {
-                toast.error(error.response?.data?.message ?? "Server Error! Please try again later");
-            });
+        let mounted = true;
+
+        const fetchCategories = () => {
+            axios
+                .get("/categories")
+                .then((res) => {
+                    if (mounted) {
+                        setCategories(res.data.data.categories);
+                    }
+                })
+                .catch((error) => {
+                    toast.error(
+                        error.response?.data?.message ??
+                            "Server Error! Please try again later"
+                    );
+                });
+        };
+        fetchCategories();
+        return () => {
+            mounted = false;
+        };
     }, []);
 
     const handleSearchInputChange = (e) => {

--- a/frontend/context/authContext/AuthActions.jsx
+++ b/frontend/context/authContext/AuthActions.jsx
@@ -23,3 +23,13 @@ export const getMeFailure = (error) => ({
 export const logout = () => ({
     type: "LOGOUT",
 });
+export const resetStart = () => ({
+    type: "RESET_START",
+});
+export const resetSuccess = () => ({
+    type: "RESET_SUCCESS",
+});
+export const resetFailure = (error) => ({
+    type: "RESET_FAILURE",
+    payload: error,
+});

--- a/frontend/context/authContext/AuthReducer.jsx
+++ b/frontend/context/authContext/AuthReducer.jsx
@@ -49,18 +49,21 @@ const AuthReducer = (state, action) => {
             return {
                 ...state,
                 isLoading: true,
+                isSuccess: false,
                 error: false
             };
         case "RESET_SUCCESS":
             return {
                 ...state,
                 isLoading: false,
+                isSuccess: true,
                 error: false
             };
         case "RESET_FAILURE":
             return {
                 ...state,
                 isLoading: false,
+                isSuccess: false,
                 error: action.payload,
             };
         default:

--- a/frontend/context/authContext/AuthReducer.jsx
+++ b/frontend/context/authContext/AuthReducer.jsx
@@ -45,6 +45,24 @@ const AuthReducer = (state, action) => {
                 isFetching: false,
                 error: false,
             };
+        case "RESET_START":
+            return {
+                ...state,
+                isLoading: true,
+                error: false
+            };
+        case "RESET_SUCCESS":
+            return {
+                ...state,
+                isLoading: false,
+                error: false
+            };
+        case "RESET_FAILURE":
+            return {
+                ...state,
+                isLoading: false,
+                error: action.payload,
+            };
         default:
             return { ...state };
     }

--- a/frontend/context/authContext/AuthReducer.jsx
+++ b/frontend/context/authContext/AuthReducer.jsx
@@ -50,21 +50,21 @@ const AuthReducer = (state, action) => {
                 ...state,
                 isLoading: true,
                 isSuccess: false,
-                error: false
+                resetError: false
             };
         case "RESET_SUCCESS":
             return {
                 ...state,
                 isLoading: false,
                 isSuccess: true,
-                error: false
+                resetError: false
             };
         case "RESET_FAILURE":
             return {
                 ...state,
                 isLoading: false,
                 isSuccess: false,
-                error: action.payload,
+                resetError: action.payload,
             };
         default:
             return { ...state };

--- a/frontend/context/authContext/apiCalls.jsx
+++ b/frontend/context/authContext/apiCalls.jsx
@@ -105,7 +105,20 @@ export const forgotPass = async (userCredentials, dispatch) => {
     }
 };
 
-export const resetPass = (dispatch) => {
+export const resetPass = async (userCredentials, dispatch) => {
     dispatch(resetStart());
-
-}
+    try {
+        const res = await axios.post("/users/reset-password", userCredentials);
+        console.log(res.data);
+        dispatch(resetSuccess());
+        toast.success("Your password has been reset successfully. Log in again to start joining chatrooms.", {
+            position: toast.POSITION.TOP_RIGHT,
+        });
+        router.push("/login");
+    } catch (err) {
+        dispatch(resetFailure(err.response.data.message));
+        toast.error(err.response.data.message, {
+            position: toast.POSITION.TOP_RIGHT,
+        });
+    }
+};

--- a/frontend/context/authContext/apiCalls.jsx
+++ b/frontend/context/authContext/apiCalls.jsx
@@ -7,6 +7,9 @@ import {
     getMeSuccess,
     getMeFailure,
     logout,
+    resetStart,
+    resetSuccess,
+    resetFailure
 } from "./AuthActions";
 import router from "next/router";
 import jwt_decode from "jwt-decode";
@@ -87,3 +90,12 @@ export const loginWithGoogle = async (userCredentials, dispatch) => {
         dispatch(authenFailure(err.response.data.message));
     }
 };
+
+export const forgotPass = (dispatch) => {
+    dispatch(resetStart());
+    // dispatch(resetFailure("Something went wrong!"));
+}
+
+export const resetPass = (dispatch) => {
+    dispatch(resetFailure("Something went wrong!"));
+}

--- a/frontend/context/authContext/apiCalls.jsx
+++ b/frontend/context/authContext/apiCalls.jsx
@@ -91,11 +91,21 @@ export const loginWithGoogle = async (userCredentials, dispatch) => {
     }
 };
 
-export const forgotPass = (dispatch) => {
+export const forgotPass = async (userCredentials, dispatch) => {
     dispatch(resetStart());
-    // dispatch(resetFailure("Something went wrong!"));
-}
+    try {
+        const res = await axios.post("/users/request-reset-password", userCredentials);
+        console.log(res.data);
+        dispatch(resetSuccess());
+        toast.success("We've sent an email allowing you to reset your password.", {
+            position: toast.POSITION.TOP_RIGHT,
+        });
+    } catch (err) {
+        dispatch(resetFailure(err.response.data.message));
+    }
+};
 
 export const resetPass = (dispatch) => {
-    dispatch(resetFailure("Something went wrong!"));
+    dispatch(resetStart());
+
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -664,6 +664,11 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.3.1.tgz",
@@ -1439,6 +1444,14 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "file-selector": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.4.tgz",
+      "integrity": "sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==",
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "fill-range": {
@@ -2949,6 +2962,16 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-dropzone": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.3.4.tgz",
+      "integrity": "sha512-B1nzNRZ4F1cnrfEC0T6KXeBN1mCPinu4JCoTrp7NjB+442KSPxqfDrw41QIA2kAwlYs1+wj/0BTedeM5hc2+xw==",
+      "requires": {
+        "attr-accept": "^2.2.1",
+        "file-selector": "^0.2.2",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-fast-compare": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
@@ -3611,6 +3634,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tty-browserify": {
       "version": "0.0.1",

--- a/frontend/pages/login.jsx
+++ b/frontend/pages/login.jsx
@@ -133,7 +133,7 @@ const Login = () => {
                             <div className="mt-4 w-full text-center">
                                 <small>
                                     <Link href="/signup">
-                                        <a className="text-gray-400 hover:text-gray-600">
+                                        <a className="text-gray-400 hover:text-indigo-600">
                                             Have not registered any account?
                                             Sign up instead{" "}
                                         </a>

--- a/frontend/pages/login.jsx
+++ b/frontend/pages/login.jsx
@@ -127,7 +127,7 @@ const Login = () => {
                                         <a className="text-indigo-400 hover:text-indigo-600">
                                             Forgot your password?
                                         </a>
-                                    </Link>
+                                    </Link> 
                                 </small>
                             </div>
                             <div className="mt-4 w-full text-center">

--- a/frontend/pages/signup.jsx
+++ b/frontend/pages/signup.jsx
@@ -174,10 +174,19 @@ const Signup = () => {
                         <div className="flex flex-wrap mt-6">
                             <div className="w-full text-center">
                                 <small>
-                                    <Link href="/login">
-                                        <a className="text-gray-300 hover:text-indigo-400">
-                                            Already have an account? Log in
-                                            instead
+                                    <Link href="/user/forgot-password">
+                                        <a className="text-indigo-400 hover:text-indigo-600">
+                                            Forgot your password?
+                                        </a>
+                                    </Link>
+                                </small>
+                            </div>
+                            <div className="mt-4 w-full text-center">
+                                <small>
+                                    <Link href="/signup">
+                                        <a className="text-gray-400 hover:text-gray-600">
+                                            Have not registered any account?
+                                            Sign up instead{" "}
                                         </a>
                                     </Link>
                                 </small>

--- a/frontend/pages/user/forgot-password.jsx
+++ b/frontend/pages/user/forgot-password.jsx
@@ -1,29 +1,25 @@
 import Link from "next/link";
 import { useState, useEffect, useContext } from "react";
-import { login, loginWithGoogle } from "../context/authContext/apiCalls";
-import router from "next/router";
-import { AuthContext } from "../context/authContext/AuthContext";
-import LoginGoogle from "../components/LoginGoogle";
-import axios from "../components/axios/index";
+import { toast } from "react-toastify";
+import { AuthContext } from "../../context/authContext/AuthContext";
+import { forgotPass } from "../../context/authContext/apiCalls";
 
-const Login = () => {
-    const [email, setEmail] = useState("");
-    const [password, setPassword] = useState("");
+const forgotPassword = () => {
     const { state, dispatch } = useContext(AuthContext);
+    const [email, setEmail] = useState("");
+    const isInvalid = email === "";
 
-    const isInvalid = email === "" || password === "";
-
-    const handleLogin = (e) => {
-        login({ email, password }, dispatch);
-        e.preventDefault();
+    const handleForgotSubmit = (e) => {
+      forgotPass(dispatch);
+      // toast.success("We've sent an email allowing you to reset your password.", {
+      //   position: toast.POSITION.BOTTOM_RIGHT,
+      // });
+      toast.error(state.error, {
+        position: toast.POSITION.BOTTOM_RIGHT,
+      });
+      console.log(state);
+      e.preventDefault();
     };
-
-    useEffect(() => {
-        // Navigate user to Homepage if find token
-        if (state.token) {
-            router.push("/");
-        }
-    }, []);
 
     return (
         <div>
@@ -34,10 +30,10 @@ const Login = () => {
                             <div className="flex-auto px-4 lg:px-10 py-10 pt-0">
                                 <div className="text-center my-6">
                                     <h6 className="text-indigo-600 text-xl font-bold ">
-                                        Log in with credentials
+                                        Forgot password
                                     </h6>
                                 </div>
-                                <form onSubmit={handleLogin}>
+                                <form onSubmit={handleForgotSubmit}>
                                     <div className="relative w-full mb-3">
                                         <label className="block uppercase text-gray-700 text-xs font-bold mb-2">
                                             Email address
@@ -51,21 +47,8 @@ const Login = () => {
                                             }
                                         />
                                     </div>
-                                    <div className="relative w-full mb-3">
-                                        <label className="block uppercase text-gray-700 text-xs font-bold mb-2">
-                                            Password
-                                        </label>
-                                        <input
-                                            type="password"
-                                            className="border-0 px-3 py-3 placeholder-gray-400 text-gray-700 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full"
-                                            placeholder="*******"
-                                            onChange={(e) =>
-                                                setPassword(e.target.value)
-                                            }
-                                        />
-                                    </div>
                                     <div className="text-center mt-6 w-full">
-                                        {state.isFetching ? (
+                                        {state.isLoading ? (
                                             <button
                                                 type="button"
                                                 className="inline-flex justify-center items-center w-full mb-1 uppercase px-6 py-3 border border-transparent text-sm font-bold rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150 disabled:cursor-not-allowed"
@@ -99,43 +82,19 @@ const Login = () => {
                                                 type="submit"
                                                 disabled={isInvalid}
                                             >
-                                                Log in
+                                                Reset Password
                                             </button>
                                         )}
                                     </div>
-                                    {state.error && (
-                                        <div className="text-red-500 text-sm mt-2">
-                                            {state.error}
-                                        </div>
-                                    )}
                                 </form>
-                            </div>
-                            <div className="rounded-t mb-0 px-10 pb-6">
-                                <hr className="mb-6 border-b-1 border-gray-400 w-4/5 mx-auto" />
-                                <div className="text-gray-500 text-center mb-3 font-bold">
-                                    <small>Or log in with</small>
-                                </div>
-                                <div className="btn-wrapper text-center">
-                                    <LoginGoogle />
-                                </div>
                             </div>
                         </div>
                         <div className="flex flex-wrap mt-6">
                             <div className="w-full text-center">
                                 <small>
-                                    <Link href="/user/forgot-password">
+                                    <Link href="/login">
                                         <a className="text-indigo-400 hover:text-indigo-600">
-                                            Forgot your password?
-                                        </a>
-                                    </Link>
-                                </small>
-                            </div>
-                            <div className="mt-4 w-full text-center">
-                                <small>
-                                    <Link href="/signup">
-                                        <a className="text-gray-400 hover:text-gray-600">
-                                            Have not registered any account?
-                                            Sign up instead{" "}
+                                            Log in with another email?
                                         </a>
                                     </Link>
                                 </small>
@@ -148,4 +107,4 @@ const Login = () => {
     );
 };
 
-export default Login;
+export default forgotPassword;

--- a/frontend/pages/user/forgot-password.jsx
+++ b/frontend/pages/user/forgot-password.jsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
 import { useState, useEffect, useContext } from "react";
-import { toast } from "react-toastify";
 import { AuthContext } from "../../context/authContext/AuthContext";
 import { forgotPass } from "../../context/authContext/apiCalls";
-import { resetStart } from "../../context/authContext/AuthActions";
 import router from "next/router";
 
 const forgotPassword = () => {
@@ -12,103 +10,114 @@ const forgotPassword = () => {
     const isInvalid = email === "";
 
     const handleForgotSubmit = (e) => {
-      forgotPass({ email }, dispatch);
-      console.log(state);
-      e.preventDefault();
+        forgotPass({ email }, dispatch);
+        console.log(state);
+        e.preventDefault();
     };
 
     useEffect(() => {
-      // Navigate user to Homepage if find token
-      if (state.token) {
-          router.push("/");
-      }
+        // Navigate user to Homepage if find token
+        if (state.token) {
+            router.push("/");
+        }
     }, []);
 
     return (
         <div>
             <div className="container mx-auto p-4 h-full">
                 <div className="flex content-center items-center justify-center h-full mt-20">
-                    <div className="w-full lg:w-4/12 px-4">
-                        <div className="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-indigo-50 border-0 ">
-                            <div className="flex-auto px-4 lg:px-10 py-10 pt-0">
-                                <div className="text-center my-6">
-                                    <h6 className="text-indigo-600 text-xl font-bold ">
-                                        Forgot password
-                                    </h6>
-                                </div>
-                                <form onSubmit={handleForgotSubmit}>
-                                    <div className="relative w-full mb-3">
-                                        <label className="block uppercase text-gray-700 text-xs font-bold mb-2">
-                                            Email address
-                                        </label>
-                                        <input
-                                            type="email"
-                                            className="border-0 px-3 py-3 placeholder-gray-400 text-gray-700 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full"
-                                            placeholder="madmax@example.com"
-                                            onChange={(e) =>
-                                                setEmail(e.target.value)
-                                            }
-                                        />
+                    {state.isSuccess ? (
+                        <div className="flex flex-col text-black px-6 py-4 border-0 rounded relative bg-gray-200 w-full lg:w-6/12">
+                            <div className="text-xl inline-block mr-5 mb-4 font-medium text-purple-700">
+                                <h1>Forgot Password</h1>
+                            </div>
+                            <div className="inline-block align-middle mr-8">
+                                <b className="capitalize">Success!</b> You should soon receive an email allowing you to reset your password. Please make sure to check your spam and trash if you can't find the email.
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="w-full lg:w-4/12 px-4">
+                            <div className="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-indigo-50 border-0 ">
+                                <div className="flex-auto px-4 lg:px-10 py-10 pt-0">
+                                    <div className="text-center my-6">
+                                        <h6 className="text-indigo-600 text-xl font-bold ">
+                                            Forgot password
+                                        </h6>
                                     </div>
-                                    <div className="text-center mt-6 w-full">
-                                        {state.isLoading ? (
-                                            <button
-                                                type="button"
-                                                className="inline-flex justify-center items-center w-full mb-1 uppercase px-6 py-3 border border-transparent text-sm font-bold rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150 disabled:cursor-not-allowed"
-                                                disabled
-                                            >
-                                                <svg
-                                                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    fill="none"
-                                                    viewBox="0 0 24 24"
-                                                >
-                                                    <circle
-                                                        className="opacity-25"
-                                                        cx="12"
-                                                        cy="12"
-                                                        r="10"
-                                                        stroke="currentColor"
-                                                        strokeWidth="4"
-                                                    ></circle>
-                                                    <path
-                                                        className="opacity-75"
-                                                        fill="currentColor"
-                                                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                                    ></path>
-                                                </svg>
-                                                Processing
-                                            </button>
-                                        ) : (
-                                            <button
-                                                className="bg-indigo-600 text-white active:bg-indigo-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 w-full disabled:bg-indigo-200 disabled:cursor-not-allowed"
-                                                type="submit"
-                                                disabled={isInvalid}
-                                            >
-                                                Reset Password
-                                            </button>
-                                        )}
-                                    </div>
-                                    {state.resetError && (
-                                        <div className="text-red-500 text-sm mt-2">
-                                            {state.resetError}
+                                    <form onSubmit={handleForgotSubmit}>
+                                        <div className="relative w-full mb-3">
+                                            <label className="block uppercase text-gray-700 text-xs font-bold mb-2">
+                                                Email address
+                                            </label>
+                                            <input
+                                                type="email"
+                                                className="border-0 px-3 py-3 placeholder-gray-400 text-gray-700 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full"
+                                                placeholder="madmax@example.com"
+                                                onChange={(e) =>
+                                                    setEmail(e.target.value)
+                                                }
+                                            />
                                         </div>
-                                    )}
-                                </form>
+                                        <div className="text-center mt-6 w-full">
+                                            {state.isLoading ? (
+                                                <button
+                                                    type="button"
+                                                    className="inline-flex justify-center items-center w-full mb-1 uppercase px-6 py-3 border border-transparent text-sm font-bold rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150 disabled:cursor-not-allowed"
+                                                    disabled
+                                                >
+                                                    <svg
+                                                        className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                    >
+                                                        <circle
+                                                            className="opacity-25"
+                                                            cx="12"
+                                                            cy="12"
+                                                            r="10"
+                                                            stroke="currentColor"
+                                                            strokeWidth="4"
+                                                        ></circle>
+                                                        <path
+                                                            className="opacity-75"
+                                                            fill="currentColor"
+                                                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                                        ></path>
+                                                    </svg>
+                                                    Processing
+                                                </button>
+                                            ) : (
+                                                <button
+                                                    className="bg-indigo-600 text-white active:bg-indigo-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 w-full disabled:bg-indigo-200 disabled:cursor-not-allowed"
+                                                    type="submit"
+                                                    disabled={isInvalid}
+                                                >
+                                                    Reset Password
+                                                </button>
+                                            )}
+                                        </div>
+                                        {state.resetError && (
+                                            <div className="text-red-500 text-sm mt-2">
+                                                {state.resetError}
+                                            </div>
+                                        )}
+                                    </form>
+                                </div>
+                            </div>
+                            <div className="flex flex-wrap mt-6">
+                                <div className="w-full text-center">
+                                    <small>
+                                        <Link href="/login">
+                                            <a className="text-indigo-400 hover:text-indigo-600">
+                                                Log in with another email?
+                                            </a>
+                                        </Link>
+                                    </small>
+                                </div>
                             </div>
                         </div>
-                        <div className="flex flex-wrap mt-6">
-                            <div className="w-full text-center">
-                                <small>
-                                    <Link href="/login">
-                                        <a className="text-indigo-400 hover:text-indigo-600">
-                                            Log in with another email?
-                                        </a>
-                                    </Link>
-                                </small>
-                            </div>
-                        </div>
-                    </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/pages/user/forgot-password.jsx
+++ b/frontend/pages/user/forgot-password.jsx
@@ -3,6 +3,8 @@ import { useState, useEffect, useContext } from "react";
 import { toast } from "react-toastify";
 import { AuthContext } from "../../context/authContext/AuthContext";
 import { forgotPass } from "../../context/authContext/apiCalls";
+import { resetStart } from "../../context/authContext/AuthActions";
+import router from "next/router";
 
 const forgotPassword = () => {
     const { state, dispatch } = useContext(AuthContext);
@@ -10,16 +12,17 @@ const forgotPassword = () => {
     const isInvalid = email === "";
 
     const handleForgotSubmit = (e) => {
-      forgotPass(dispatch);
-      // toast.success("We've sent an email allowing you to reset your password.", {
-      //   position: toast.POSITION.BOTTOM_RIGHT,
-      // });
-      toast.error(state.error, {
-        position: toast.POSITION.BOTTOM_RIGHT,
-      });
+      forgotPass({ email }, dispatch);
       console.log(state);
       e.preventDefault();
     };
+
+    useEffect(() => {
+      // Navigate user to Homepage if find token
+      if (state.token) {
+          router.push("/");
+      }
+    }, []);
 
     return (
         <div>
@@ -86,6 +89,11 @@ const forgotPassword = () => {
                                             </button>
                                         )}
                                     </div>
+                                    {state.resetError && (
+                                        <div className="text-red-500 text-sm mt-2">
+                                            {state.resetError}
+                                        </div>
+                                    )}
                                 </form>
                             </div>
                         </div>

--- a/frontend/pages/user/reset-password.jsx
+++ b/frontend/pages/user/reset-password.jsx
@@ -1,26 +1,30 @@
 import Link from "next/link";
 import { useState, useEffect, useContext } from "react";
-import { toast } from "react-toastify";
 import { AuthContext } from "../../context/authContext/AuthContext";
 import { resetPass } from "../../context/authContext/apiCalls";
+import { useRouter } from "next/router";
 
 const resetPassword = () => {
     const { state, dispatch } = useContext(AuthContext);
-    const [newPassword, setNewPassword] = useState("");
+    const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
-    const isInvalid = newPassword === "" || newPassword !== confirmPassword;
+    const isInvalid = password === "" || password !== confirmPassword;
+
+    const router = useRouter();
+    const userId = router.query.id;
+    const token = router.query.token;
 
     const handleResetSubmit = (e) => {
-      resetPass(dispatch);
-      // toast.success("We've sent an email allowing you to reset your password.", {
-      //   position: toast.POSITION.BOTTOM_RIGHT,
-      // });
-      toast.error(state.error, {
-        position: toast.POSITION.BOTTOM_RIGHT,
-      });
-      console.log(state);
-      e.preventDefault();
+        resetPass({ userId, token, password }, dispatch);
+        e.preventDefault();
     };
+
+    useEffect(() => {
+        // Navigate user to Homepage if find token
+        if (state.token) {
+            router.push("/");
+        }
+    }, []);
 
     return (
         <div>
@@ -44,7 +48,7 @@ const resetPassword = () => {
                                             className="border-0 px-3 py-3 placeholder-gray-400 text-gray-700 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full"
                                             placeholder="********"
                                             onChange={(e) =>
-                                              setNewPassword(e.target.value)
+                                                setPassword(e.target.value)
                                             }
                                         />
                                     </div>

--- a/frontend/pages/user/reset-password.jsx
+++ b/frontend/pages/user/reset-password.jsx
@@ -1,0 +1,124 @@
+import Link from "next/link";
+import { useState, useEffect, useContext } from "react";
+import { toast } from "react-toastify";
+import { AuthContext } from "../../context/authContext/AuthContext";
+import { resetPass } from "../../context/authContext/apiCalls";
+
+const resetPassword = () => {
+    const { state, dispatch } = useContext(AuthContext);
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const isInvalid = newPassword === "" || newPassword !== confirmPassword;
+
+    const handleResetSubmit = (e) => {
+      resetPass(dispatch);
+      // toast.success("We've sent an email allowing you to reset your password.", {
+      //   position: toast.POSITION.BOTTOM_RIGHT,
+      // });
+      toast.error(state.error, {
+        position: toast.POSITION.BOTTOM_RIGHT,
+      });
+      console.log(state);
+      e.preventDefault();
+    };
+
+    return (
+        <div>
+            <div className="container mx-auto p-4 h-full">
+                <div className="flex content-center items-center justify-center h-full mt-20">
+                    <div className="w-full lg:w-4/12 px-4">
+                        <div className="relative flex flex-col min-w-0 break-words w-full mb-6 shadow-lg rounded-lg bg-indigo-50 border-0 ">
+                            <div className="flex-auto px-4 lg:px-10 py-10 pt-0">
+                                <div className="text-center my-6">
+                                    <h6 className="text-indigo-600 text-xl font-bold ">
+                                        Reset password
+                                    </h6>
+                                </div>
+                                <form onSubmit={handleResetSubmit}>
+                                    <div className="relative w-full mb-3">
+                                        <label className="block uppercase text-gray-700 text-xs font-bold mb-2">
+                                            New Password
+                                        </label>
+                                        <input
+                                            type="password"
+                                            className="border-0 px-3 py-3 placeholder-gray-400 text-gray-700 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full"
+                                            placeholder="********"
+                                            onChange={(e) =>
+                                              setNewPassword(e.target.value)
+                                            }
+                                        />
+                                    </div>
+                                    <div className="relative w-full mb-3">
+                                        <label className="block uppercase text-gray-700 text-xs font-bold mb-2">
+                                            Confirm Password
+                                        </label>
+                                        <input
+                                            type="password"
+                                            className="border-0 px-3 py-3 placeholder-gray-400 text-gray-700 bg-white rounded text-sm shadow focus:outline-none focus:ring w-full"
+                                            placeholder="********"
+                                            onChange={(e) =>
+                                              setConfirmPassword(e.target.value)
+                                            }
+                                        />
+                                    </div>
+                                    <div className="text-center mt-6 w-full">
+                                        {state.isLoading ? (
+                                            <button
+                                                type="button"
+                                                className="inline-flex justify-center items-center w-full mb-1 uppercase px-6 py-3 border border-transparent text-sm font-bold rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition ease-in-out duration-150 disabled:cursor-not-allowed"
+                                                disabled
+                                            >
+                                                <svg
+                                                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    fill="none"
+                                                    viewBox="0 0 24 24"
+                                                >
+                                                    <circle
+                                                        className="opacity-25"
+                                                        cx="12"
+                                                        cy="12"
+                                                        r="10"
+                                                        stroke="currentColor"
+                                                        strokeWidth="4"
+                                                    ></circle>
+                                                    <path
+                                                        className="opacity-75"
+                                                        fill="currentColor"
+                                                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                                    ></path>
+                                                </svg>
+                                                Processing
+                                            </button>
+                                        ) : (
+                                            <button
+                                                className="bg-indigo-600 text-white active:bg-indigo-700 text-sm font-bold uppercase px-6 py-3 rounded shadow hover:shadow-lg outline-none focus:outline-none mr-1 mb-1 w-full disabled:bg-indigo-200 disabled:cursor-not-allowed"
+                                                type="submit"
+                                                disabled={isInvalid}
+                                            >
+                                                Reset Password
+                                            </button>
+                                        )}
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                        <div className="flex flex-wrap mt-6">
+                            <div className="w-full text-center">
+                                <small>
+                                    <Link href="/login">
+                                        <a className="text-indigo-400 hover:text-indigo-600">
+                                            Log in with another email?
+                                        </a>
+                                    </Link>
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default resetPassword;


### PR DESCRIPTION
### Change-log
- Introduce pages `Forgot password` & `Reset Password` to allow users to reset their password
- Consume APIs `users/request-reset-password` & `users/reset-password`
- Display success/error message according to server's response
- Cleanup useEffect hook for `NavBar` component

### How-to-test
 - Checkout this branch and start frontend, backend server
 - Log out your current account
 - Go to Signup/ Login page then click the `Forgot password` link to navigate to Forgot Password page
 - Use your registered email to check if the users can receive the reset password link in their mailbox (You can use a temporary email from https://temp-mail.org/en/view/6132eb3d46c9f5011919f849 if don't want to use your private email for receiving the reset link)
 - Change the Reset Password URL from `https://cosc-2769-rmit.vercel.app/user/reset-password?` to `localhost:3000/user/reset-password?`
 - Test multiple cases to ensure that 
- [ ] User can not request reset password with an unregistered email
- [ ] User can not use an expired link to reset password (exp. time 15 mins)
- [ ] Users are not able to access page `/user/forgot-password` OR `/user/reset-password` after logging in

<img width="1434" alt="Screen Shot 2021-09-04 at 10 42 57" src="https://user-images.githubusercontent.com/23531403/132081849-83403a61-3a9d-4e15-9359-fe0b27a22104.png">

<img width="1421" alt="Screen Shot 2021-09-04 at 10 44 02" src="https://user-images.githubusercontent.com/23531403/132081862-6a122821-2b8e-47b2-899e-013499c9cb83.png">
