### PR TITLE
Feat/fix datetime picker

### DIFF
--- a/frontend/components/UpdateForm.js
+++ b/frontend/components/UpdateForm.js
@@ -8,6 +8,7 @@ import { useDropzone } from "react-dropzone";
 import router from "next/router";
 import { StarIcon } from "@heroicons/react/solid";
 import MinDateTimeFormatter from "../utils/MinDateTimeFormat";
+import dayjs from "dayjs";
 
 const roomReducer = (state, action) => {
     switch (action.type) {
@@ -56,7 +57,7 @@ export default function UpdateForm({ roomDetail }) {
     const [title, setTitle] = useState(roomDetail.title);
     const [description, setDescription] = useState(roomDetail.description);
     const [price, setPrice] = useState(roomDetail.price);
-    const [startDate, setStartDate] = useState(new Date());
+    const [startDate, setStartDate] = useState(roomDetail.startedAt);
     const [oldThumb, setOldThumb] = useState(roomDetail.thumbnail);
 
     const isInvalid =
@@ -428,6 +429,9 @@ export default function UpdateForm({ roomDetail }) {
                                                     setStartDate(e.target.value)
                                                 }
                                                 min={minDate}
+                                                value={dayjs(startDate).format(
+                                                    "YYYY-MM-DDThh:mm"
+                                                )}
                                             />
                                         </div>
                                     </div>

--- a/frontend/components/UpdateForm.js
+++ b/frontend/components/UpdateForm.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { useState, useReducer, useEffect, useContext } from "react";
-import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { AuthContext } from "../context/authContext/AuthContext";
 import CategoryDropDown from "./CategoryDropDown";
@@ -8,6 +7,7 @@ import axios from "./axios";
 import { useDropzone } from "react-dropzone";
 import router from "next/router";
 import { StarIcon } from "@heroicons/react/solid";
+import MinDateTimeFormatter from "../utils/MinDateTimeFormat";
 
 const roomReducer = (state, action) => {
     switch (action.type) {
@@ -191,6 +191,9 @@ export default function UpdateForm({ roomDetail }) {
             });
     };
 
+    // const currentDate = new Date();
+    const minDate = MinDateTimeFormatter(new Date());
+    console.log(minDate);
     console.log(oldThumb.length);
     console.log(files.length);
     console.log(oldThumb);
@@ -418,11 +421,13 @@ export default function UpdateForm({ roomDetail }) {
                                             Started date
                                         </label>
                                         <div className="mt-1 relative rounded-md shadow-sm">
-                                            <DatePicker
-                                                selected={startDate}
-                                                onChange={(date) =>
-                                                    setStartDate(date)
+                                            <input
+                                                type="datetime-local"
+                                                className="rounded-md text-gray-800"
+                                                onChange={(e) =>
+                                                    setStartDate(e.target.value)
                                                 }
+                                                min={minDate}
                                             />
                                         </div>
                                     </div>

--- a/frontend/pages/room/create.jsx
+++ b/frontend/pages/room/create.jsx
@@ -2,7 +2,6 @@ import { useState, useReducer, useEffect, useContext } from "react";
 import axios from "../../components/axios";
 import router from "next/router";
 import CategoryDropDown from "../../components/CategoryDropDown";
-import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { AuthContext } from "../../context/authContext/AuthContext";
 import { toast } from "react-toastify";
@@ -411,13 +410,14 @@ const Create = () => {
                                     <div className="grid grid-cols-4 gap-6">
                                         <div className="col-span-4 lg:col-span-2">
                                             <label className="block text-sm font-medium text-gray-700">
-                                                Started date
+                                                Started date time
                                             </label>
                                             <div className="mt-1 relative rounded-md shadow-sm">
-                                                <DatePicker
-                                                    selected={startDate}
-                                                    onChange={(date) =>
-                                                        setStartDate(date)
+                                                <input
+                                                    type="datetime-local"
+                                                    className="rounded-md text-gray-800"
+                                                    onChange={(e) =>
+                                                        setStartDate(e.target.value)
                                                     }
                                                 />
                                             </div>
@@ -437,22 +437,6 @@ const Create = () => {
                         </form>
                     </div>
                 </div>
-                {/* {room.error && (
-                    <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mt-5">
-                        <span className="inline-block align-middle mr-8">
-                            <b className="font-bold">Error!</b>{" "}
-                            {room.error.message}
-                        </span>
-                        <button
-                            className="absolute bg-transparent text-2xl font-semibold leading-none right-0 top-0 mt-4 mr-6 outline-none focus:outline-none"
-                            onClick={() => {
-                                dispatchRoom({ type: "ROOM_INIT" });
-                            }}
-                        >
-                            <span>×</span>
-                        </button>
-                    </div>
-                )} */}
             </div>
         </div>
     );

--- a/frontend/pages/room/create.jsx
+++ b/frontend/pages/room/create.jsx
@@ -7,6 +7,7 @@ import { AuthContext } from "../../context/authContext/AuthContext";
 import { toast } from "react-toastify";
 import { useDropzone } from "react-dropzone";
 import { StarIcon } from "@heroicons/react/solid";
+import MinDateTimeFormatter from "../../utils/MinDateTimeFormat";
 
 const INIT_CATEGORY = [{ name: "Select Category" }];
 
@@ -198,6 +199,9 @@ const Create = () => {
         },
         [files]
     );
+
+    const minDate = MinDateTimeFormatter(new Date());
+    console.log(minDate);
 
     return (
         <div>
@@ -419,6 +423,7 @@ const Create = () => {
                                                     onChange={(e) =>
                                                         setStartDate(e.target.value)
                                                     }
+                                                    min={minDate}
                                                 />
                                             </div>
                                         </div>

--- a/frontend/utils/MinDateTimeFormat.js
+++ b/frontend/utils/MinDateTimeFormat.js
@@ -1,0 +1,16 @@
+export default function MinDateTimeFormatter(str = null) {
+  if (!str) return "";
+  let date = new Date(str);
+  let year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  let dt = date.getDate() + 1;
+
+  if (dt < 10) {
+      dt = "0" + dt;
+  }
+  if (month < 10) {
+      month = "0" + month;
+  }
+  
+  return `${year}-${month}-${dt}T00:00`;
+}


### PR DESCRIPTION
### Change-log
- Add `time picker` when creating & updating room
- Introduce `MinDateTimeFormat` to prevent users to select a date time in the past

### Acceptance Criteria
- Verify that experts can select date & time when creating and updating room
- Experts are not able to select current & previous date
- Default value are not being selected/ displayed to ensure that experts must verify the started date time before submitting

<img width="921" alt="Screen Shot 2021-09-14 at 11 34 35" src="https://user-images.githubusercontent.com/23531403/133195574-6dcda920-b8be-480a-8bca-c25b67427f3a.png">
